### PR TITLE
build: update appveyor image to latest version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@
 
 version: 1.0.{build}
 build_cloud: electronhq-16-core
-image: e-107.0.5286.0
+image: e-108.0.5329.0
 environment:
   GIT_CACHE_PATH: C:\Users\appveyor\libcc_cache
   ELECTRON_OUT_DIR: Default


### PR DESCRIPTION
This PR updates appveyor.yml to the latest baked image, e-108.0.5329.0.